### PR TITLE
General chore, renaming etc.

### DIFF
--- a/use-package-ensure-guix.el
+++ b/use-package-ensure-guix.el
@@ -20,8 +20,7 @@
   (interactive)
   (guix-profile-info-show-packages use-package-ensure-guix-profile))
 
-
-(defun use-package-guix-package-installed-p (package)
+(defun use-package-ensure-guix-installed-p (package)
   (bui-assoc-value package 'installed))
 
 (defun use-package-guix-canonicalize-name (package-name)
@@ -49,7 +48,7 @@ already there."
 (defun use-package-guix-install-package (package)
   "Install PACKAGE, a guix package as returned by `emacs-package->guix-package`,
 into `use-package-ensure-guix-profile`"
-  (if (use-package-guix-package-installed-p package)
+  (if (use-package-ensure-guix-installed-p package)
       t
     (guix-process-package-actions
      use-package-ensure-guix-profile
@@ -69,7 +68,7 @@ into `use-package-ensure-guix-profile`"
 	  (setq package (car package)))
 
 	(let ((package (emacs-package->guix-package (use-package-as-string package))))
-	  (unless (use-package-guix-package-installed-p package)
+	  (unless (use-package-ensure-guix-installed-p package)
 	    (use-package-guix-install-package package))
 	  (use-package-guix-update-load-path))))))
 

--- a/use-package-ensure-guix.el
+++ b/use-package-ensure-guix.el
@@ -16,9 +16,6 @@
   :type 'string
   :group 'use-package-ensure-guix)
 
-(defvar use-package-ensured-guix-packages '()
-  "List of guix packages which use-package ensures.")
-
 (defun use-package-guix-show-ensured ()
   (interactive)
   (guix-profile-info-show-packages use-package-ensure-guix-profile))

--- a/use-package-ensure-guix.el
+++ b/use-package-ensure-guix.el
@@ -83,4 +83,4 @@ into `use-package-profile`"
   (bui-get-display-entries 'guix-profile 'info
 			   (list 'profile use-package-profile)))
 
-(provide 'use-package-guix)
+(provide 'use-package-ensure-guix)

--- a/use-package-ensure-guix.el
+++ b/use-package-ensure-guix.el
@@ -11,7 +11,7 @@
   "use-package support for guix"
   :group 'use-package-ensure)
 
-(defcustom use-package-profile (concat (getenv "HOME") "/.emacs.d/guix-profile")
+(defcustom use-package-ensure-guix-profile (concat (getenv "HOME") "/.emacs.d/guix-profile")
   "Location of use-package guix profile"
   :type 'string
   :group 'use-package-ensure-guix)
@@ -21,7 +21,7 @@
 
 (defun use-package-guix-show-ensured ()
   (interactive)
-  (guix-profile-info-show-packages use-package-profile))
+  (guix-profile-info-show-packages use-package-ensure-guix-profile))
 
 
 (defun use-package-guix-package-installed-p (package)
@@ -35,7 +35,7 @@
 
 (defun emacs-package->guix-package (package)
   "Return guix package from package name"
-  (car (guix-output-list-get-entries use-package-profile 'name
+  (car (guix-output-list-get-entries use-package-ensure-guix-profile 'name
 				     (use-package-guix-canonicalize-name package))))
 
 ;;;###autoload
@@ -45,17 +45,17 @@ already there."
   (mapc (lambda (x)
 	  (unless (member x load-path)
 	    (add-to-list 'load-path x)))
-	(directory-files (concat use-package-profile "/share/emacs/site-lisp") t)))
+	(directory-files (concat use-package-ensure-guix-profile "/share/emacs/site-lisp") t)))
 
 
 ;;;###autoload
 (defun use-package-guix-install-package (package)
   "Install PACKAGE, a guix package as returned by `emacs-package->guix-package`,
-into `use-package-profile`"
+into `use-package-ensure-guix-profile`"
   (if (use-package-guix-package-installed-p package)
       t
     (guix-process-package-actions
-     use-package-profile
+     use-package-ensure-guix-profile
      `((install (,(string-to-number (car (split-string (bui-entry-id package) ":"))) "out")))
      (current-buffer))))
 
@@ -78,9 +78,9 @@ into `use-package-profile`"
 
 ;;;###autoload
 (defun use-package-guix-profile ()
-  "Display interface for `guix-use-package-profile'."
+  "Display interface for `guix-use-package-ensure-guix-profile'."
   (interactive)
   (bui-get-display-entries 'guix-profile 'info
-			   (list 'profile use-package-profile)))
+			   (list 'profile use-package-ensure-guix-profile)))
 
 (provide 'use-package-ensure-guix)

--- a/use-package-ensure-guix.el
+++ b/use-package-ensure-guix.el
@@ -44,26 +44,26 @@
   :type 'string
   :group 'use-package-ensure-guix)
 
-(defun use-package-guix-show-ensured ()
+(defun use-package-ensure-guix-show-packages ()
   (interactive)
   (guix-profile-info-show-packages use-package-ensure-guix-profile))
 
 (defun use-package-ensure-guix-installed-p (package)
   (bui-assoc-value package 'installed))
 
-(defun use-package-guix-canonicalize-name (package-name)
+(defun use-package-ensure-guix--get-guix-package-name (package-name)
   "Make sure package name has \"emacs-\" prefix"
   (if (string-match "^emacs-.+" package-name)
       package-name
     (concat "emacs-" package-name)))
 
-(defun emacs-package->guix-package (package)
+(defun use-package-ensure-guix--get-guix-package (package)
   "Return guix package from package name"
   (car (guix-output-list-get-entries use-package-ensure-guix-profile 'name
-				     (use-package-guix-canonicalize-name package))))
+		 (use-package-ensure-guix--get-guix-package-name package))))
 
 ;;;###autoload
-(defun use-package-guix-update-load-path ()
+(defun use-package-ensure-guix-update-load-path ()
   "Ensures all ensured packages are added to the load-path if not
 already there."
   (mapc (lambda (x)
@@ -73,8 +73,8 @@ already there."
 
 
 ;;;###autoload
-(defun use-package-guix-install-package (package)
-  "Install PACKAGE, a guix package as returned by `emacs-package->guix-package`,
+(defun use-package-ensure-guix--install (package)
+  "Install PACKAGE, a guix package as returned by `use-package-ensure-guix--get-guix-package`,
 into `use-package-ensure-guix-profile`"
   (if (use-package-ensure-guix-installed-p package)
       t
@@ -95,14 +95,15 @@ into `use-package-ensure-guix-profile`"
 	(when (consp package)
 	  (setq package (car package)))
 
-	(let ((package (emacs-package->guix-package (use-package-as-string package))))
+	(let ((package (use-package-ensure-guix--get-guix-package (use-package-as-string package))))
 	  (unless (use-package-ensure-guix-installed-p package)
-	    (use-package-guix-install-package package))
-	  (use-package-guix-update-load-path))))))
+	    (use-package-ensure-guix--install package))
+	  (use-package-ensure-guix-update-load-path))))))
 
 ;;;###autoload
-(defun use-package-guix-profile ()
-  "Display interface for `guix-use-package-ensure-guix-profile'."
+(defun use-package-ensure-guix-profile-info ()
+  "Display interactive information for
+`guix-use-package-ensure-guix-profile'."
   (interactive)
   (bui-get-display-entries 'guix-profile 'info
 			   (list 'profile use-package-ensure-guix-profile)))

--- a/use-package-ensure-guix.el
+++ b/use-package-ensure-guix.el
@@ -1,4 +1,32 @@
-;;; Copyright © 2022-2023 Mitchell Schmeisser <mitchellschmeisser@librem.one>
+;;; use-package-ensure-guix.el --- Ensure used packages with Guix
+
+;; Copyright (C) 2023  Mitchell Schmeisser <mitchellschmeisser@librem.one>
+
+;; Author: Mitchell Schmeisser <mitchellschmeisser@librem.one>
+;; Maintainer: Mitchell Schmeisser <mitchellschmeisser@librem.one>
+;; URL: https://github.com/paperclip4465/use-package-ensure-guix
+;; Keywords: dotemacs config package guix
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This package allows you to make use-package.el ensure that Emacs-packages
+;; are installed by using GNU Guix. It will install respective packages into
+;; an Emacs-specific guix-profile.
+
+;;; Code:
 
 (require 'guix)
 (require 'guix-misc)
@@ -80,3 +108,5 @@ into `use-package-ensure-guix-profile`"
 			   (list 'profile use-package-ensure-guix-profile)))
 
 (provide 'use-package-ensure-guix)
+
+;;; use-package-ensure-guix.el ends here

--- a/use-package-guix.el
+++ b/use-package-guix.el
@@ -1,3 +1,5 @@
+;;; Copyright © 2022-2023 Mitchell Schmeisser <mitchellschmeisser@librem.one>
+
 (require 'guix)
 (require 'guix-profiles)
 (require 'guix-read)

--- a/use-package-guix.el
+++ b/use-package-guix.el
@@ -7,14 +7,14 @@
 (require 'guix-ui-package)
 (require 'guix-utils)
 
-(defgroup use-package-guix nil
+(defgroup use-package-ensure-guix nil
   "use-package support for guix"
   :group 'use-package-ensure)
 
 (defcustom use-package-profile (concat (getenv "HOME") "/.emacs.d/guix-profile")
   "Location of use-package guix profile"
   :type 'string
-  :group 'use-package-guix)
+  :group 'use-package-ensure-guix)
 
 (defvar use-package-ensured-guix-packages '()
   "List of guix packages which use-package ensures.")

--- a/use-package-guix.el
+++ b/use-package-guix.el
@@ -1,11 +1,11 @@
 ;;; Copyright © 2022-2023 Mitchell Schmeisser <mitchellschmeisser@librem.one>
 
 (require 'guix)
+(require 'guix-misc)
 (require 'guix-profiles)
 (require 'guix-read)
 (require 'guix-ui-package)
 (require 'guix-utils)
-(require 'guix-misc)
 
 (defgroup use-package-guix nil
   "use-package support for guix"


### PR DESCRIPTION
- add copyright notice
- sort require'd features alphabetically: alphabetically sorted stuff is better maintainable.
- rename group into use-package-ensure-guix: i think the repository, package and the group should have the same name.
- rename feature and file into use-package-ensure-guix
- rename use-package-profile into use-package-ensure-guix-profile: i'm in favor of using the package name as prefix for everything.
- remove unused variable use-package-ensured-guix-packages
- rename use-package-guix-package-installed-p into use-package-ensure-guix-installed-p
- add package commentary template with M-x auto-insert: after having inserted the copyright notice manually, i found out about this builtin template function.
- rename everything to use prefix use-package-ensure-guix